### PR TITLE
Fix: 편지 목록 조회 응답 분리

### DIFF
--- a/src/main/java/com/mjuletter/domain/letter/application/LetterService.java
+++ b/src/main/java/com/mjuletter/domain/letter/application/LetterService.java
@@ -2,9 +2,9 @@ package com.mjuletter.domain.letter.application;
 
 import com.mjuletter.domain.letter.domain.Letter;
 import com.mjuletter.domain.letter.domain.repository.LetterRepository;
-import com.mjuletter.domain.letter.dto.response.LetterResponse;
+import com.mjuletter.domain.letter.dto.response.ReceivedLetterResponse;
+import com.mjuletter.domain.letter.dto.response.SentLetterResponse;
 import com.mjuletter.domain.notification.application.NotificationService;
-import com.mjuletter.domain.notification.domain.Notification;
 import com.mjuletter.domain.user.domain.User;
 import com.mjuletter.domain.user.domain.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -47,7 +47,7 @@ public class LetterService {
 
 
     @Transactional(readOnly = true)
-    public ResponseEntity<List<LetterResponse>> getReceivedLetters(Long userId) {
+    public ResponseEntity<List<ReceivedLetterResponse>> getReceivedLetters(Long userId) {
         // 사용자 ID로 사용자 정보 가져오기
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("User not found"));
@@ -56,8 +56,8 @@ public class LetterService {
         List<Letter> receivedLetters = letterRepository.findByRecipientOrderByCreatedAtAsc(user);
 
         // 받은 편지 리스트를 LetterResponse 리스트로 변환
-        List<LetterResponse> letterResponses = receivedLetters.stream()
-                .map(letter -> new LetterResponse(
+        List<ReceivedLetterResponse> letterResponses = receivedLetters.stream()
+                .map(letter -> new ReceivedLetterResponse(
                         letter.getId(),
                         letter.getContent(),
                         letter.isAnonymous(),
@@ -70,7 +70,7 @@ public class LetterService {
     }
 
     @Transactional(readOnly = true)
-    public ResponseEntity<List<LetterResponse>> getSentLetters(Long userId) {
+    public ResponseEntity<List<SentLetterResponse>> getSentLetters(Long userId) {
         // 사용자 ID로 사용자 정보 가져오기
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("User not found"));
@@ -79,8 +79,8 @@ public class LetterService {
         List<Letter> sentLetters = letterRepository.findBySenderOrderByCreatedAtAsc(user);
 
         // 보낸 편지 리스트를 LetterResponse 리스트로 변환
-        List<LetterResponse> letterResponses = sentLetters.stream()
-                .map(letter -> new LetterResponse(
+        List<SentLetterResponse> letterResponses = sentLetters.stream()
+                .map(letter -> new SentLetterResponse(
                         letter.getId(),
                         letter.getContent(),
                         false, // 익명 여부는 보낸 편지에서는 항상 false
@@ -101,7 +101,6 @@ public class LetterService {
         if (!userId.equals(letter.getSender().getId())) {
             throw new AccessDeniedException("You are not authorized to delete this letter");
         }
-
         // Delete the letter
         letterRepository.delete(letter);
     }

--- a/src/main/java/com/mjuletter/domain/letter/dto/response/ReceivedLetterResponse.java
+++ b/src/main/java/com/mjuletter/domain/letter/dto/response/ReceivedLetterResponse.java
@@ -1,0 +1,18 @@
+package com.mjuletter.domain.letter.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReceivedLetterResponse {
+    private Long id;
+    private String content;
+    private boolean anonymous; // 익명 여부
+    private String senderName; // 받은 사람 이름
+    private String senderProfileImage; // 보낸 사람의 프로필 이미지
+
+}

--- a/src/main/java/com/mjuletter/domain/letter/dto/response/SentLetterResponse.java
+++ b/src/main/java/com/mjuletter/domain/letter/dto/response/SentLetterResponse.java
@@ -3,17 +3,15 @@ package com.mjuletter.domain.letter.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class LetterResponse {
+public class SentLetterResponse {
     private Long id;
     private String content;
     private boolean anonymous; // 익명 여부
     private String recipientName; // 받은 사람 이름
-    private String senderProfileImage; // 보낸 사람의 프로필 이미지
+    private String recipientProfileImage; // 보낸 사람의 프로필 이미지
 
 }

--- a/src/main/java/com/mjuletter/domain/letter/presentation/LetterController.java
+++ b/src/main/java/com/mjuletter/domain/letter/presentation/LetterController.java
@@ -2,7 +2,8 @@ package com.mjuletter.domain.letter.presentation;
 
 import com.mjuletter.domain.letter.application.LetterService;
 import com.mjuletter.domain.letter.dto.request.LetterRequest;
-import com.mjuletter.domain.letter.dto.response.LetterResponse;
+import com.mjuletter.domain.letter.dto.response.ReceivedLetterResponse;
+import com.mjuletter.domain.letter.dto.response.SentLetterResponse;
 import com.mjuletter.global.config.security.token.CurrentUser;
 import com.mjuletter.global.config.security.token.UserPrincipal;
 import com.mjuletter.global.payload.ApiResponse;
@@ -38,13 +39,13 @@ public class LetterController {
 
     @Operation(summary = "사용자가 받은 편지 리스트 조회", description = "사용자가 받은 편지 리스트를 조회합니다.")
     @GetMapping("/")
-    public ResponseEntity<List<LetterResponse>> getReceivedLetters(@CurrentUser UserPrincipal userPrincipal) {
+    public ResponseEntity<List<ReceivedLetterResponse>> getReceivedLetters(@CurrentUser UserPrincipal userPrincipal) {
         return letterService.getReceivedLetters(userPrincipal.getId());
     }
 
     @Operation(summary = "사용자가 보낸 편지 리스트 조회", description = "사용자가 보낸 편지 리스트를 조회합니다.")
     @GetMapping("/sent")
-    public ResponseEntity<List<LetterResponse>> getSentLetters(@CurrentUser UserPrincipal userPrincipal) {
+    public ResponseEntity<List<SentLetterResponse>> getSentLetters(@CurrentUser UserPrincipal userPrincipal) {
         // 현재 인증된 사용자의 ID를 가져와서 사용자가 보낸 편지 리스트를 조회합니다.
         return letterService.getSentLetters(userPrincipal.getId());
     }


### PR DESCRIPTION
---
name: PULL_REQUEST_TEMPLATE
about: Suggest an idea for this project
title: "[FEAT] 기능 구현"
labels: ''
assignees: ''

---

## Description
* 내가 쓴 편지 목록 -> 받는 사람 정보 포함
* 내가 받은 편지 목록 -> 보낸 사람 정보 포함

## To be noted

## issue number
#27 
## Checklist
- [x] label
- [x] issue number
- [x] conflict resolve
