### PR TITLE
[FEAT] 다른 사용자가 받은 편지지 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/mjuletter/domain/letter/presentation/LetterController.java
+++ b/src/main/java/com/mjuletter/domain/letter/presentation/LetterController.java
@@ -63,6 +63,9 @@ public class LetterController {
         return ResponseEntity.ok(new ApiResponse(true, "내가 받은 롤링페이퍼가 삭제되었습니다."));
     }
 
-
-
+    @Operation(summary = "다른 유저의 편지 조회", description = "다른 유저의 편지를 조회하는 API")
+    @GetMapping("/{userId}")
+    public ResponseEntity<?> getOtherUserLetters(@CurrentUser UserPrincipal userPrincipal, @PathVariable Long userId) {
+        return letterService.getOtherReceivedLetters(userPrincipal, userId);
+    }
 }


### PR DESCRIPTION

## Description
- 다른 사용자가 받은 편지지 목록 조회 기능 구현
## To be noted
- 파라미터로 다른 유저의 아이디를 통해 해당 유저의 편지지 목록을 조회합니다.
## issue number

## Checklist
- [x] label
- [ ] issue number
- [x] conflict resolve
